### PR TITLE
Changes to dependencies

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,20 +13,19 @@ my $meta_merge = {
 };
 
 WriteMakefile(
-    'NAME'         => 'File::Comments',
-    'VERSION_FROM' => 'lib/File/Comments.pm', # finds $VERSION
-    'PREREQ_PM'    => {
+    'NAME'              => 'File::Comments',
+    'VERSION_FROM'      => 'lib/File/Comments.pm', # finds $VERSION
+    'ABSTRACT_FROM'     => 'lib/File/Comments.pm',
+    'AUTHOR'            => 'Mike Schilli <cpan@perlmeister.com>',
+    'MIN_PERL_VERSION'  => '5.6.0',
+    'PREREQ_PM'         => {
           HTML::TokeParser  => 2.28,
           HTML::TreeBuilder => 0,
           PPI               => 1.115,
           Log::Log4perl     => 0.50,
           Sysadm::Install   => 0.11,
-          Archive::Tar      => 1.22,
           Module::Pluggable => 2.4,
           Pod::Parser       => 1.14,
           }, # e.g., Module::Name => 1.1
     $ExtUtils::MakeMaker::VERSION >= 6.50 ? (%$meta_merge) : (),
-    ($] >= 5.005 ?    ## Add these new keywords supported since 5.005
-      (ABSTRACT_FROM => 'lib/File/Comments.pm',
-       AUTHOR     => 'Mike Schilli <cpan@perlmeister.com>') : ()),
 );

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -12,12 +12,15 @@ my $meta_merge = {
     }
 };
 
+my $min_perl_ver = {
+    'MIN_PERL_VERSION'  => '5.6.0'
+};
+
 WriteMakefile(
     'NAME'              => 'File::Comments',
     'VERSION_FROM'      => 'lib/File/Comments.pm', # finds $VERSION
     'ABSTRACT_FROM'     => 'lib/File/Comments.pm',
     'AUTHOR'            => 'Mike Schilli <cpan@perlmeister.com>',
-    'MIN_PERL_VERSION'  => '5.6.0',
     'PREREQ_PM'         => {
           HTML::TokeParser  => 2.28,
           HTML::TreeBuilder => 0,
@@ -27,5 +30,6 @@ WriteMakefile(
           Module::Pluggable => 2.4,
           Pod::Parser       => 1.14,
           }, # e.g., Module::Name => 1.1
-    $ExtUtils::MakeMaker::VERSION >= 6.50 ? (%$meta_merge) : (),
+    $ExtUtils::MakeMaker::VERSION >= 6.50 ? (%$meta_merge)   : (),
+    $ExtUtils::MakeMaker::VERSION >= 6.48 ? (%$min_perl_ver) : (),
 );


### PR DESCRIPTION
There are 3 minor changes to Makefile.PL here:
1. I could not find any reference to Archive::Tar within the codebase and the tests seem to pass fine without it. Therefore this dependency has been removed from the list.
2. perlver suggests that throughout the code the minimum version required is 5.6.0 so this has now been stipulated.
3. As a result of (2) there seemed no point checking for versions above 5.005 any more. The affected fields have therefore been inserted unconditionally instead.
